### PR TITLE
Fix makefile for OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc/html/
 get_automatic_changelog.sh
 wiki
+Test_Driver/

--- a/makefile
+++ b/makefile
@@ -9,6 +9,10 @@ LIBS    =
 ifeq ("${FC}","")
 	FC      = gfortran
 endif
+ifeq ("${FC}","f77")
+  # under OSX FC is set by default to the nonexistent f77
+  FC      = gfortran
+endif
 # This should not only detect gfortran/f77, but also a GNU-based mpif90:
 DOGNU = $(shell ${FC} --version | grep -i GNU > /dev/null; expr 1 - $$?)
 


### PR DESCRIPTION
OSX has FC set to f77 in default make. OSX used to have fortran installed, but not anymore since they moved to llvm/clang as the default compiler. Most OSX people install gfortran using macports or using homebrew. 
